### PR TITLE
feat!: remove buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # c32check
 
-[Crockford base-32](https://en.wikipedia.org/wiki/Base32#Crockford's_Base32) encoding library
-with 4-byte checksum.
+[Crockford base-32](https://en.wikipedia.org/wiki/Base32#Crockford's_Base32)
+encoding library with 4-byte checksum.
 
-This library is meant for generating and decoding Stacks addresses on the
-Blockstack blockchain.
+This library is meant for generating and decoding addresses on the Stacks
+blockchain.
 
 ## How it works
 
@@ -30,9 +30,10 @@ This is similar to base58check encoding, for example.
 
 ## c32 Addresses
 
-Specific to Blockstack, the Stacks blockchain uses c32-encoded public key
-hashes as addresses. Specifically, a **c32check address** is a c32check-encoded
-ripemd160 hash.
+The Stacks blockchain uses c32-encoded public key hashes as addresses.
+Specifically, a **c32check address** is a c32check-encoded ripemd160 hash.
+
+---
 
 # Examples
 
@@ -77,7 +78,8 @@ ripemd160 hash.
 
 ## c32address, c32addressDecode
 
-**NOTE**: these methods only work on ripemd160 hashes
+> **Note**:
+> These methods only work on ripemd160 hashes
 
 ```
 > hash160 = 'a46ff88886c2ef9762d970b4d2c63678835bd39d'
@@ -92,8 +94,9 @@ ripemd160 hash.
 
 ## c32ToB58, b58ToC32
 
-**NOTE**: Common address versions are converted between c32check
-and base58check seamlessly, in order to accomodate Stacks addresses.
+> **Note**:
+> Common address versions are converted between c32check and base58check
+> seamlessly, in order to accomodate Stacks addresses.
 
 ```
 > b58addr = '16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Blockstack blockchain.
 
 ## How it works
 
-Each c32check string encodes a 1-byte version and a 4-byte checksum.  When
+Each c32check string encodes a 1-byte version and a 4-byte checksum. When
 decoded as a hex string, the wire format looks like this:
 
 ```
@@ -17,7 +17,7 @@ decoded as a hex string, the wire format looks like this:
 version     n-byte hex payload          4-byte hash
 ```
 
-If `version` is the version byte (a 1-byte `number`) and `payload` is the raw 
+If `version` is the version byte (a 1-byte `number`) and `payload` is the raw
 bytes (e.g. as a `string`), then the `checksum` is calculated as follows:
 
 ```
@@ -31,7 +31,7 @@ This is similar to base58check encoding, for example.
 ## c32 Addresses
 
 Specific to Blockstack, the Stacks blockchain uses c32-encoded public key
-hashes as addresses.  Specifically, a **c32check address** is a c32check-encoded
+hashes as addresses. Specifically, a **c32check address** is a c32check-encoded
 ripemd160 hash.
 
 # Examples
@@ -44,7 +44,7 @@ ripemd160 hash.
   c32checkDecode: [Function: c32checkDecode],
   c32address: [Function: c32address],
   c32addressDecode: [Function: c32addressDecode],
-  versions: 
+  versions:
    { mainnet: { p2pkh: 22, p2sh: 20 },
      testnet: { p2pkh: 26, p2sh: 21 } },
   c32ToB58: [Function: c32ToB58],
@@ -70,7 +70,7 @@ ripemd160 hash.
 > c32check.c32checkEncode(version, Buffer.from('hello world').toString('hex'))
 'CD1JPRV3F41VPYWKCCGRMASC8'
 > c32check.c32checkDecode('CD1JPRV3F41VPYWKCCGRMASC8')
-[ 12, '68656c6c6f20776f726c64' ] 
+[ 12, '68656c6c6f20776f726c64' ]
 > Buffer.from('68656c6c6f20776f726c64', 'hex').toString()
 'hello world'
 ```
@@ -103,11 +103,12 @@ and base58check seamlessly, in order to accomodate Stacks addresses.
 > c32check.c32ToB58('SPWNYDJ3STG7XH7ERWXMV6MQ7Q6EATWVY5Q1QMP8')
 '16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg'
 ```
+
 ```
 > b58addr = '3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r'
 '3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r'
 > c32check.b58ToC32(b58addr)
 'SM1Y6EXF21RZ9739DFTEQKB1H044BMM0XVCM4A4NY'
 > c32check.c32ToB58('SM1Y6EXF21RZ9739DFTEQKB1H044BMM0XVCM4A4NY')
-3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r'
+'3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r'
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
+        "@noble/hashes": "^1.1.2",
         "base-x": "^4.0.0",
-        "buffer": "^6.0.3",
-        "cross-sha256": "^1.2.0"
+        "buffer": "^6.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.17.10",
@@ -2452,6 +2452,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4309,38 +4320,6 @@
         "node": ">=10.14",
         "npm": ">=6",
         "yarn": ">=1"
-      }
-    },
-    "node_modules/cross-sha256": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cross-sha256/-/cross-sha256-1.2.0.tgz",
-      "integrity": "sha512-KViLNMDZKV7jwFqjFx+rNhG26amnFYYQ0S+VaFlVvpk8tM+2XbFia/don/SjGHg9WQxnFVi6z64CGPuF3T+nNw==",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "node_modules/cross-sha256/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cross-spawn": {
@@ -11193,6 +11172,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12574,25 +12558,6 @@
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"
-      }
-    },
-    "cross-sha256": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cross-sha256/-/cross-sha256-1.2.0.tgz",
-      "integrity": "sha512-KViLNMDZKV7jwFqjFx+rNhG26amnFYYQ0S+VaFlVvpk8tM+2XbFia/don/SjGHg9WQxnFVi6z64CGPuF3T+nNw==",
-      "requires": {
-        "buffer": "^5.6.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
       }
     },
     "cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
-        "base-x": "^4.0.0",
-        "buffer": "^6.0.3"
+        "base-x": "^4.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.17.10",
@@ -3858,11 +3857,6 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
-    "node_modules/base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -3914,29 +3908,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5807,25 +5778,6 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -12213,11 +12165,6 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
-    "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -12253,15 +12200,6 @@
         "electron-to-chromium": "^1.4.202",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.5"
-      }
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -13741,11 +13679,6 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
       "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.1.2",
-    "base-x": "^4.0.0",
-    "buffer": "^6.0.3"
+    "base-x": "^4.0.0"
   },
   "engines": {
     "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -112,9 +112,9 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
+    "@noble/hashes": "^1.1.2",
     "base-x": "^4.0.0",
-    "buffer": "^6.0.3",
-    "cross-sha256": "^1.2.0"
+    "buffer": "^6.0.3"
   },
   "engines": {
     "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/blockstack/c32check.git"
+    "url": "git+https://github.com/stacks-network/c32check.git"
   },
   "author": {
     "name": "Jude Nelson",
@@ -33,7 +33,7 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/blockstack/c32check/issues"
+    "url": "https://github.com/stacks-network/c32check/issues"
   },
   "keywords": [
     "blockchain",
@@ -62,7 +62,7 @@
     "identity",
     "ethereum"
   ],
-  "homepage": "https://blockstack.org",
+  "homepage": "https://stacks.co",
   "contributors": [
     {
       "name": "Jude Nelson",

--- a/src/address.ts
+++ b/src/address.ts
@@ -1,5 +1,6 @@
 import { c32checkEncode, c32checkDecode } from './checksum';
 import * as base58check from './base58check';
+import { bytesToHex } from '@noble/hashes/utils';
 
 export const versions = {
   mainnet: {
@@ -68,8 +69,8 @@ export function c32addressDecode(c32addr: string): [number, string] {
  */
 export function b58ToC32(b58check: string, version: number = -1): string {
   const addrInfo = base58check.decode(b58check);
-  const hash160String = addrInfo.data.toString('hex');
-  const addrVersion = parseInt(addrInfo.prefix.toString('hex'), 16);
+  const hash160String = bytesToHex(addrInfo.data);
+  const addrVersion = parseInt(bytesToHex(addrInfo.prefix), 16);
   let stacksVersion;
 
   if (version < 0) {

--- a/src/base58check.ts
+++ b/src/base58check.ts
@@ -5,7 +5,8 @@
  */
 'use strict';
 import { Buffer } from 'buffer/';
-import { hashSha256 } from 'cross-sha256';
+
+import { sha256 } from '@noble/hashes/sha256';
 import * as basex from 'base-x';
 
 const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
@@ -25,8 +26,8 @@ export function encode(
     prefix = new Buffer(prefix, encoding);
   }
   let hash = Buffer.concat([prefix, data]);
-  hash = hashSha256(hash) as Buffer;
-  hash = hashSha256(hash) as Buffer;
+  hash = sha256(hash) as Buffer;
+  hash = sha256(hash) as Buffer;
   hash = Buffer.concat([prefix, data, hash.slice(0, 4)]);
   return basex(ALPHABET).encode(hash);
 }
@@ -36,8 +37,8 @@ export function decode(string: string, encoding?: BufferEncoding) {
   let prefix: Buffer | string = buffer.slice(0, 1);
   let data: Buffer | string = buffer.slice(1, -4);
   let hash = Buffer.concat([prefix, data]);
-  hash = hashSha256(hash) as Buffer;
-  hash = hashSha256(hash) as Buffer;
+  hash = sha256(hash) as Buffer;
+  hash = sha256(hash) as Buffer;
   buffer.slice(-4).forEach((check, index) => {
     if (check !== hash[index]) {
       throw new Error('Invalid checksum');

--- a/src/checksum.ts
+++ b/src/checksum.ts
@@ -1,5 +1,5 @@
 import { sha256 } from '@noble/hashes/sha256';
-import { Buffer } from 'buffer/';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { c32, c32decode, c32encode, c32normalize } from './encoding';
 
 /**
@@ -8,8 +8,8 @@ import { c32, c32decode, c32encode, c32normalize } from './encoding';
  * @returns {string} the c32 checksum, as a bin-encoded string
  */
 function c32checksum(dataHex: string): string {
-  const dataHash = sha256(sha256(Buffer.from(dataHex, 'hex')));
-  const checksum = dataHash.slice(0, 4).toString('hex');
+  const dataHash = sha256(sha256(hexToBytes(dataHex)));
+  const checksum = bytesToHex(dataHash.slice(0, 4));
   return checksum;
 }
 

--- a/src/checksum.ts
+++ b/src/checksum.ts
@@ -1,6 +1,6 @@
+import { sha256 } from '@noble/hashes/sha256';
 import { Buffer } from 'buffer/';
-import { c32encode, c32decode, c32normalize, c32 } from './encoding';
-import { hashSha256 } from 'cross-sha256';
+import { c32, c32decode, c32encode, c32normalize } from './encoding';
 
 /**
  * Get the c32check checksum of a hex-encoded string
@@ -8,7 +8,7 @@ import { hashSha256 } from 'cross-sha256';
  * @returns {string} the c32 checksum, as a bin-encoded string
  */
 function c32checksum(dataHex: string): string {
-  const dataHash = hashSha256(hashSha256(Buffer.from(dataHex, 'hex')));
+  const dataHash = sha256(sha256(Buffer.from(dataHex, 'hex')));
   const checksum = dataHash.slice(0, 4).toString('hex');
   return checksum;
 }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,4 +1,5 @@
-import { Buffer } from 'buffer/';
+import { hexToBytes } from '@noble/hashes/utils';
+
 export const c32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 const hex = '0123456789abcdef';
 
@@ -52,9 +53,7 @@ export function c32encode(inputHex: string, minLength?: number): string {
 
   res = res.slice(C32leadingZeros);
 
-  const zeroPrefix = Buffer.from(inputHex, 'hex')
-    .toString()
-    .match(/^\u0000*/);
+  const zeroPrefix = new TextDecoder().decode(hexToBytes(inputHex)).match(/^\u0000*/);
   const numLeadingZeroBytesInHex = zeroPrefix ? zeroPrefix[0].length : 0;
 
   for (let i = 0; i < numLeadingZeroBytesInHex; i++) {

--- a/tests/unitTests/src/index.ts
+++ b/tests/unitTests/src/index.ts
@@ -10,6 +10,7 @@ import {
   c32ToB58,
   b58ToC32,
 } from '../../../src/index';
+import { encode } from '../../../src/base58check';
 import * as c32check from '../../../src/index';
 
 export function c32encodingTests() {
@@ -833,6 +834,25 @@ export function c32ToB58Test() {
       c32check.c32ToB58('SM1Y6EXF21RZ9739DFTEQKB1H044BMM0XVCM4A4NY'),
       '3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r'
     );
+  });
+
+  const invalidEncodeParameterTypes = [
+    [{} as string, 'abc'],
+    ['abc', {} as string],
+    [{} as string, {} as string],
+  ];
+
+  test('encode throws on invalid types', t => {
+    t.plan(invalidEncodeParameterTypes.length);
+
+    for (const [p1, p2] of invalidEncodeParameterTypes) {
+      try {
+        encode(p1, p2);
+        t.ok(false, 'encode returned on invalid type');
+      } catch (e) {
+        t.ok(true, 'encode threw error on invalid type');
+      }
+    }
   });
 }
 

--- a/tests/unitTests/src/index.ts
+++ b/tests/unitTests/src/index.ts
@@ -10,6 +10,7 @@ import {
   c32ToB58,
   b58ToC32,
 } from '../../../src/index';
+import * as c32check from '../../../src/index';
 
 export function c32encodingTests() {
   const hexStrings = [
@@ -790,6 +791,48 @@ export function c32ToB58Test() {
         );
       }
     }
+  });
+
+  test('README examples with legacy Buffer', t => {
+    let version, b58addr;
+    t.plan(15);
+
+    // ## c32encode, c32decode
+    t.equal(c32check.c32encode(Buffer.from('hello world').toString('hex')), '38CNP6RVS0EXQQ4V34');
+    t.equal(c32check.c32decode('38CNP6RVS0EXQQ4V34'), '68656c6c6f20776f726c64');
+    t.equal(Buffer.from('68656c6c6f20776f726c64', 'hex').toString(), 'hello world');
+
+    // ## c32checkEncode, c32checkDecode
+    version = 12;
+    t.equal(
+      c32check.c32checkEncode(version, Buffer.from('hello world').toString('hex')),
+      'CD1JPRV3F41VPYWKCCGRMASC8'
+    );
+    t.equal(c32check.c32checkDecode('CD1JPRV3F41VPYWKCCGRMASC8')[0], 12);
+    t.equal(c32check.c32checkDecode('CD1JPRV3F41VPYWKCCGRMASC8')[1], '68656c6c6f20776f726c64');
+    t.equal(Buffer.from('68656c6c6f20776f726c64', 'hex').toString(), 'hello world');
+
+    // ## c32address, c32addressDecode
+    version = 22;
+    const hash160 = 'a46ff88886c2ef9762d970b4d2c63678835bd39d';
+    t.equal(c32check.versions.mainnet.p2pkh, version);
+    t.equal(c32check.c32address(version, hash160), 'SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7');
+    t.equal(c32check.c32addressDecode('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7')[0], version);
+    t.equal(c32check.c32addressDecode('SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7')[1], hash160);
+
+    // ## c32ToB58, b58ToC32
+    b58addr = '16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg';
+    t.equal(c32check.b58ToC32(b58addr), 'SPWNYDJ3STG7XH7ERWXMV6MQ7Q6EATWVY5Q1QMP8');
+    t.equal(
+      c32check.c32ToB58('SPWNYDJ3STG7XH7ERWXMV6MQ7Q6EATWVY5Q1QMP8'),
+      '16EMaNw3pkn3v6f2BgnSSs53zAKH4Q8YJg'
+    );
+    b58addr = '3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r';
+    t.equal(c32check.b58ToC32(b58addr), 'SM1Y6EXF21RZ9739DFTEQKB1H044BMM0XVCM4A4NY');
+    t.equal(
+      c32check.c32ToB58('SM1Y6EXF21RZ9739DFTEQKB1H044BMM0XVCM4A4NY'),
+      '3D2oetdNuZUqQHPJmcMDDHYoqkyNVsFk9r'
+    );
   });
 }
 


### PR DESCRIPTION
- switches to `noble` hashes (as other stacks npm packages)
- remove `buffer` package and replaces with usage of `Uint8Array`
  - still interoperable with buffer (technically no complete breaking change, but might be shown in TS environments)